### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/haskell-updates-status.yml
+++ b/.github/workflows/haskell-updates-status.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v26
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
 
       - name: Run ./update.sh
         run: |


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: DeterminateSystems/magic-nix-cache-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.