### PR TITLE
Fix update.sh in CI

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/haskell-updates.tar.gz
-#! nix-shell -p "with import (builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/nixos-23.05.tar.gz) {}; hydra_unstable"
+#! nix-shell -p "with import (builtins.fetchTarball https://github.com/NixOS/nixpkgs/archive/nixos-24.11.tar.gz) {}; hydra_unstable"
 #! nix-shell -p "writers.writeHaskellBin \"hydra-report\" {libraries = with haskellPackages; [aeson req];} (path + \"/maintainers/scripts/haskell/hydra-report.hs\")"
 #! nix-shell -p "writers.writeBashBin \"get-nixpkgs-path\" \"echo \${path}\""
 
@@ -20,7 +20,7 @@
 # I wouldn't be surprised if there wasn't an easier way to get the path to the
 # nixpkgs repo from within nix-shell.
 #
-# TODO: This uses `hydra_unstable` from 23.05 because `hydra-unstable` is sometimes broken
+# TODO: This uses `hydra_unstable` from 24.11 because `hydra-unstable` is sometimes broken
 # on `master`.
 
 set -u -e
@@ -39,7 +39,7 @@ fi
 #
 # Note that the `hydra-report ping-maintainers` command must be run the root of
 # the nixpkgs repo.
-(cd "$(get-nixpkgs-path)" && hydra-report ping-maintainers) > README.md
+(cd "$(get-nixpkgs-path)" && LC_ALL=en_US.UTF-8 hydra-report ping-maintainers) > README.md
 
 # Add the footer to the end of the README.
 cat README-footer.md >> README.md


### PR DESCRIPTION
I don't think the update from 23.05 -> 24.11 is necessary to make this work, but I didn't want to try again without.

It's working now, see https://github.com/wolfgangwalther/nix-haskell-updates-status/actions/runs/13348364308/job/37281695524!

Resolves #6