### PR TITLE
Remove magic-nix-cache

### DIFF
--- a/.github/workflows/haskell-updates-status.yml
+++ b/.github/workflows/haskell-updates-status.yml
@@ -21,8 +21,6 @@ jobs:
 
       - uses: cachix/install-nix-action@v26
 
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
-
       - name: Run ./update.sh
         run: |
           # Create the updated README.md using the script from this checkout.


### PR DESCRIPTION
It's non-functional right now and actually only leads to failed workflows taking 6 hours instead of 6 minutes.

Waste of resources!

Resolves #8

@sternenseemann 