### PR TITLE
Set NIX_PATH in action since inner hydra-report nix-shell needs it

### DIFF
--- a/.github/workflows/haskell-updates-status.yml
+++ b/.github/workflows/haskell-updates-status.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v26
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/haskell-updates.tar.gz
 
       - name: Run ./update.sh
         run: |

--- a/update.sh
+++ b/update.sh
@@ -1,8 +1,4 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash
-#! nix-shell -p nix
-#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/haskell-updates.tar.gz
-#! nix-shell -p "writers.writeBashBin \"get-nixpkgs-path\" \"echo \${path}\""
+#! /bin/sh
 
 # This script updates the README.md with the latest build report from Hydra for
 # the `haskell-updates` branch in Nixpkgs.
@@ -10,14 +6,11 @@
 # See https://github.com/NixOS/nixpkgs/blob/haskell-updates/pkgs/development/haskell-modules/HACKING.md
 # for more information about this process.
 #
-# TODO: The `get-nixpkgs-path` is used to get the path to the nixpkgs repo that
-# has been downloaded for the nix-shell -I argument.  This is somewhat of a hack.
-# I wouldn't be surprised if there wasn't an easier way to get the path to the
-# nixpkgs repo from within nix-shell.
+# For this to work NIX_PATH must be set to point <nixpkgs> to the haskell-updates branch.
 
 set -u -e
 
-nixpkgs="$(get-nixpkgs-path)"
+nixpkgs="$(nix-instantiate --find-file nixpkgs)"
 echo "Resolved <nixpkgs> to $nixpkgs"
 
 hydra_report="$nixpkgs/maintainers/scripts/haskell/hydra-report.hs"


### PR DESCRIPTION
This seems to be the simplest solution instead of using -I to change NIX_PATH which doesn't actually change the environment variable in the nix-shell. Hence we need get-nixpkgs-path and the hydra-report.hs nix-shell we invoke doesn't see the updated NIX_PATH.

cc @wolfgangwalther 